### PR TITLE
Add namely/docker-protoc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@
 - [Evans](https://github.com/ktr0731/evans) - more expressive universal gRPC (CLI) client
 - [grpcurl](https://github.com/fullstorydev/grpcurl) - Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers
 - [danby](https://github.com/ericbets/danby) - A grpc proxy for the browser 
+- [docker-protoc](https://github.com/namely/docker-protoc) - Dockerized protoc, grpc-gateway, and grpc_cli commands bundled with Google API libraries. 
 
 <a name="other-go"></a>
 ### Go


### PR DESCRIPTION
We use this at Namely for generating our protofiles, using grpc_cli and generating a grpc-gateway container.