### PR TITLE
Add grpc-json-proxy to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@
 - [danby](https://github.com/ericbets/danby) - A grpc proxy for the browser 
 - [docker-protoc](https://github.com/namely/docker-protoc) - Dockerized protoc, grpc-gateway, and grpc_cli commands bundled with Google API libraries
 - [ghz](https://github.com/bojand/ghz) - Simple gRPC benchmarking and load testing tool inspired by hey and grpcurl 
+- [grpc-json-proxy](https://github.com/jnewmano/grpc-json-proxy) - A proxy which allows existing tools like Postman or curl to interact with gRPC servers
 
 <a name="other-go"></a>
 ### Go


### PR DESCRIPTION
[grpc-json-proxy](https://github.com/jnewmano/grpc-json-proxy) is recommended by [omgrpc](https://github.com/troylelandshields/omgrpc) as a replacement