### PR TITLE
readme: include protolock in list of proto tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -289,6 +289,7 @@ Tim Burks
 - [prototool](https://github.com/uber/prototool) - Compile, lint, and format Protobuf files, and generate stubs for any lanuguage/plugin, along with Vim/IDE integration
 - [protoc-gen-validate](https://github.com/lyft/protoc-gen-validate) - Protoc plugin to generate polyglot message validators
 - [go-proto-validators](https://github.com/mwitkow/go-proto-validators) - Generate message validators from .proto annotations, used in `grpc_validator` Go gRPC middleware.
+- [protolock](https://github.com/nilslice/protolock) - Protocol Buffer companion tool to `protoc` and `git`. Track your .proto files and prevent changes to messages and services which impact API compatibilty.
 
 ### Similar
 


### PR DESCRIPTION
[`protolock`](https://github.com/nilslice/protolock) is a utility to help ensure no API-breaking changes are made to a set of protocol buffer definitions. This includes all native protobuf types and services + RPCs. 

A list of all rules enforced by `protolock` include: 
```
No Using Reserved Fields
No Removing Reserved Fields
No Removing Fields Without Reserve
No Changing Field IDs
No Changing Field Types
No Changing Field Names
No Removing RPCs
No Changing RPC Signature
```

A more comprehensive presentation of the tool can be found [here](https://docs.google.com/presentation/d/1QUGZ2VqTAIR-lF-dXI7b_vUjFA3C45bXpGhPWUX7AvI/edit#slide=id.p). 