### PR TITLE
Add the Mu library for Scala

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@
 
 - [ScalaPB](https://scalapb.github.io/) - Protocol Buffer Compiler for Scala
 - [Akka-gRPC](https://developer.lightbend.com/docs/akka-grpc/current/) - Akka gRPC provides support for building streaming gRPC servers and clients on top of Akka Streams.
+- [Mu](https://higherkindness.io/mu/) - Mu RPC is a purely functional library for building RPC endpoint-based services with support for gRPC and HTTP/2
 
 <a name="other-dart"></a>
 ### Dart


### PR DESCRIPTION
Perhaps less well-known library for writing gRPC compatible services in Scala, [Mu](https://higherkindness.io/mu/) allows you to do so in purely functional style. :)

Let me know if I should change the link to point to github repo instead of docsite.