### PR TITLE
add Globular and Lighter (Examples)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -340,6 +340,8 @@ Tim Burks
 - [go-micro-services](https://github.com/harlow/go-micro-services) - An demonstration of Golang micro-services that expose a HTTP/JSON frontend and then leverages gRPC for inter-service communication
 - [Colossus](https://github.com/lucperkins/colossus) - An example multi-language gRPC microservice architecture built by Bazel and targeting Kubernetes
 - [coolstore-microservices](https://github.com/vietnam-devs/coolstore-microservices) - A containerized polyglot gRPC microservices based on .NET Core, Nodejs and more running on Istio
+- [Globular](https://gitlab.com/inbitcoin/globular) - Cross-implementation Lightning Network wallet (Lighter gRPC client, Android)
+- [Lighter](https://gitlab.com/inbitcoin/lighter) - Lightning Network node wrapper for c-lightning, eclair and LND (gRPC server, Python)
 
 <a name="res-misc"></a>
 ### Miscellaneous


### PR DESCRIPTION
We think our two projects could be interesting as examples.

Lighter's [API documentation site](https://lighter-doc.inbitcoin.it/) could also be useful, not sure where it would fit, though.