### PR TITLE
Adds protoc-gen-map to protobuf tool list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -385,6 +385,7 @@ Tim Burks
 - [protoc-gen-validate](https://github.com/lyft/protoc-gen-validate) - Protoc plugin to generate polyglot message validators
 - [go-proto-validators](https://github.com/mwitkow/go-proto-validators) - Generate message validators from .proto annotations, used in `grpc_validator` Go gRPC middleware.
 - [protolock](https://github.com/nilslice/protolock) - Protocol Buffer companion tool to `protoc` and `git`. Track your .proto files and prevent changes to messages and services which impact API compatibilty.
+- [protoc-gen-map](https://github.com/jackskj/protoc-gen-map) - SQL data mapper framework for Protocol Buffers.
 
 ### Similar
 


### PR DESCRIPTION
Please include protoc-gen-map in the list of protoc tools. 
For more information on the framework, please visit https://github.com/jackskj/protoc-gen-map