### PR TITLE
Add to CLI: proto2asciidoc - tool for generating AsciiDoc from .proto

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@
 - [grpcurl](https://github.com/fullstorydev/grpcurl) - Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers
 - [protodot](https://github.com/seamia/protodot) - Transforming your .proto files into .dot files (and .svg, .png if you happen to have graphviz installed)
 - [grpc-client-cli](https://github.com/vadimi/grpc-client-cli) - interactive gRPC client
+- [proto2asciidoc](https://github.com/productsupcom/proto2asciidoc) - Generate AsciiDoc documentation from a .proto file
 
 <a name="tools-gui"></a>
 ### GUI
@@ -313,6 +314,7 @@
 - [Part 2: Demystifying gRPC](https://dev-state.com/posts/grpc_framework_2/) - Extend the service with gRPC streaming and Python backend.
 - [Part 3: Demystifying gRPC](https://dev-state.com/posts/grpc_framework_3/) - Add Unary and Stream gRPC Interceptors to a service and provide REST endpoints with grpc-gateway.
 - [gRPC in Microservices](https://milad.dev/posts/grpc-in-microservices/) - Tutorial on using gRPC in microservice architetures.
+- [gRPC and Protobuffer API Documentation with proto2asciidoc and code2asciidoc](https://blog.productsup.dev/2020/05/grpc-and-protobuffer-api-documentation-with-proto2asciidoc-and-code2asciidoc/) - Tutorial on generating AsciiDoc documentation from a .proto file, includes a small gRPC demo project too.
 
 <a name="res-videos"></a>
 ### Videos


### PR DESCRIPTION
Added a CLI tool for proto2asciidoc and a tutorial on a blog site how to use the CLI itself.

CLI: https://github.com/productsupcom/proto2asciidoc
Tutorial: https://blog.productsup.dev/2020/05/grpc-and-protobuffer-api-documentation-with-proto2asciidoc-and-code2asciidoc/