### PR TITLE
Add PropaneDB

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@
 - [protoc-gen-hbs](https://github.com/gponsinet/protoc-gen-hbs) - Fast and easy protobuf generation with handlebars and some helpers
 - [grpcson](https://github.com/siyanew/grpcson) - An easy to use proxy which translates JSON HTTP requests to gRPC calls with web ui
 - [rk-grpc](https://github.com/rookie-ninja/rk-grpc) - Middleware and bootstrapper library for gRPC with logging, metrics, auth, tracing etc.
+- [PropaneDB](https://github.com/elan8/propanedb) - A Protocol Buffers database with gRPC API and Golang driver.
 
 <a name="lang"></a>
 ## Language-Specific


### PR DESCRIPTION
PropaneDB is a new Protocol Buffer database with a gRPC API. It is inspired by ProfaneDB and could be useful in combination with gRPC microservices. 