### PR TITLE
Add httpyac and vscode-httpyac

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@
 - [gcall](https://github.com/bojand/gcall) - Simple Node.js gRPC command line interface
 - [Evans](https://github.com/ktr0731/evans) - more expressive universal gRPC (CLI) client
 - [grpcurl](https://github.com/fullstorydev/grpcurl) - Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers
+- [httpyac](https://httpyac.github.io/guide/installation_cli.html) - a command line client for executing integration tests for all kinds of requests (gRPC, HTTP, MQTT, Websocket). 
 - [protodot](https://github.com/seamia/protodot) - Transforming your .proto files into .dot files (and .svg, .png if you happen to have graphviz installed)
 - [grpc-client-cli](https://github.com/vadimi/grpc-client-cli) - interactive gRPC client
 - [proto2asciidoc](https://github.com/productsupcom/proto2asciidoc) - Generate AsciiDoc documentation from a .proto file
@@ -98,6 +99,7 @@
 - [grpcui](https://github.com/fullstorydev/grpcui) - An interactive web UI for gRPC, along the lines of postman (also, a Go library for embedding these web UIs into Go HTTP servers)
 - [BloomRPC](https://github.com/uw-labs/bloomrpc) - A nice and simple GUI Client. Exploring and interacting with gRPC services has never been simpler, Inspired By GraphQL-Playground and Postman
 - [gRPCox](https://github.com/gusaul/grpcox) - Like Postman, but for gRPC. web based GUI Client for gRPC, extremely easy to use.
+- [vscode-httpyac](https://httpyac.github.io/guide/installation_vscode.html) - A VSCode extension which supports sending all kinds of requests (gRPC, HTTP, MQTT, Websocket)
 - [Milkman](https://github.com/warmuuh/milkman) - Extensible alternative to Postman for crafting all kinds of requests, not only for gRPC, also http, sql etc.
 - [MuninRPC](https://github.com/muninrpc/muninrpc) - Protobuf request and response testing application under the gRPC system.
 - [Delivery](https://github.com/kfwerf/delivery) - A simple electron app for gRPC that uses gRPCurl to autodetect all endpoints/methods and their request bodies, just modify the JSON body. Simplicity in mind.


### PR DESCRIPTION
Hi,

I am the author of [httpyac](https://httpyac.github.io/guide/installation_cli.html#intallation) (CLI) and [vscode-httpyac](https://httpyac.github.io/guide/installation_vscode.html#installation) (VSCode Extension) which supports requesting all kinds of gRPC types.

It would be my pleasure to be listed on the site as well.

Thanks.