### PR TITLE
tools: remove grpc/homebrew-grpc ref as it is not maintained

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,6 @@
 - [gRPC Web](https://github.com/grpc/grpc-web) - gRPC for Web Clients
 - [gRPC Ecosystem](https://github.com/grpc-ecosystem) - gRPC Ecosystem that complements gRPC
 - [gRPC contrib](https://github.com/grpc/grpc-contrib) - Known useful contributions around github
-- [Homebrew gRPC](https://github.com/grpc/homebrew-grpc) - gRPC formulae repo for Homebrew
 - [grpc_cli](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md) - gRPC CLI tool
 
 ## Tools


### PR DESCRIPTION
It looks like both grpc and google-protobuf are not maintained in that repo, might be good to reference the homebrew-core ones.