### PR TITLE
added grpc-pentest-suite

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@
 - [PropaneDB](https://github.com/elan8/propanedb) - A Protocol Buffers database with gRPC API and Golang driver.
 - [APISIX](https://github.com/apache/apisix) - An api gateway that supports gRPC, HTTP(s) to gRPC and gRPC web request proxying.
 - [Zilla](https://github.com/aklivity/zilla) - An API gateway built for event-driven architectures and streaming that supports standard protocols such as HTTP, SSE, gRPC, MQTT and the native Kafka protocol.
+- [grpc-pentest-suite](https://github.com/nxenon/grpc-pentest-suite) - A collection of tools for pentesting gRPC-Web, including a Burp Suite extension for manipulating gRPC-Web payloads.
 
 <a name="lang"></a>
 


### PR DESCRIPTION
Add grpc-pentest-suite repository which is a collection of tools for pentesting gRPC-Web, including a Burp Suite extension for manipulating gRPC-Web payloads. It also includes YouTube video that helps with pentesting and analyzing gRPC-Web.