### PR TITLE
chore: postman

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@
 <a name="tools-gui"></a>
 ### GUI
 
+- [Postman](https://postman.com/products/grpc-client) - Create, test, and debug gRPC services directly from Postman, including for protobuf files and schema discovery
 - [letmegrpc](https://github.com/gogo/letmegrpc) - Generate a web form gui from a grpc specification
 - [omgRPC](https://github.com/troylelandshields/omgrpc) (Deprecated) - A GUI client for interacting with gRPC services, similar to what Postman is for REST APIs
 - [grpcui](https://github.com/fullstorydev/grpcui) - An interactive web UI for gRPC, along the lines of postman (also, a Go library for embedding these web UIs into Go HTTP servers)

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@
 <a name="tools-gui"></a>
 ### GUI
 
-- [Postman](https://postman.com/) - Create, test, and debug gRPC services directly from Postman, including for protobuf files and schema discovery
+- [Postman](https://postman.com/) - Create, test, and debug gRPC services directly from Postman
 - [letmegrpc](https://github.com/gogo/letmegrpc) - Generate a web form gui from a grpc specification
 - [omgRPC](https://github.com/troylelandshields/omgrpc) (Deprecated) - A GUI client for interacting with gRPC services, similar to what Postman is for REST APIs
 - [grpcui](https://github.com/fullstorydev/grpcui) - An interactive web UI for gRPC, along the lines of postman (also, a Go library for embedding these web UIs into Go HTTP servers)

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@
 <a name="tools-gui"></a>
 ### GUI
 
-- [Postman](https://postman.com/products/grpc-client) - Create, test, and debug gRPC services directly from Postman, including for protobuf files and schema discovery
+- [Postman](https://postman.com/) - Create, test, and debug gRPC services directly from Postman, including for protobuf files and schema discovery
 - [letmegrpc](https://github.com/gogo/letmegrpc) - Generate a web form gui from a grpc specification
 - [omgRPC](https://github.com/troylelandshields/omgrpc) (Deprecated) - A GUI client for interacting with gRPC services, similar to what Postman is for REST APIs
 - [grpcui](https://github.com/fullstorydev/grpcui) - An interactive web UI for gRPC, along the lines of postman (also, a Go library for embedding these web UIs into Go HTTP servers)


### PR DESCRIPTION
## description

This PR adds Postman to the list of GUI clients, since gRPC is now fully supported by Postman, alongside other protocols like REST (of course), GraphQL, Websockets, and so forth.

## context

Hello! I'm new at Postman, and we actually fully support gRPC and we'd love to guide any new developers using gRPC for the first time to check it out.

Totally un-opinionated on where we add the link, but I added it at the top since I do ultimately think it's a great resource to use for someone testing out a gRPC service (or services).

<img width="470" alt="Screenshot 2023-11-01 at 14 55 31" src="https://github.com/grpc-ecosystem/awesome-grpc/assets/3924690/2a5258d3-fe0a-4de5-9f4b-329781fcb3e4">
