### PR TITLE
Add the `wtx` project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -274,6 +274,7 @@
 - [grpc-rust](https://github.com/stepancheg/grpc-rust) - Rust implementation of gRPC
 - [tower-grpc](https://github.com/tower-rs/tower-grpc) (Deprecated) - A client and server gRPC implementation based on Tower. Deprecated in favour of tonic
 - [tonic](https://github.com/hyperium/tonic) - A native gRPC client & server implementation with async/await support
+- [wtx](https://github.com/c410-f3r/wtx) - RFC7541 and RFC9113 implementation with built-in support for `gRPC` connections.
 
 <a name="lang-hs"></a>
 ### Haskell


### PR DESCRIPTION
[wtx](https://github.com/c410-f3r/wtx) is a [RFC7541](https://datatracker.ietf.org/doc/html/rfc7541) and [RFC9113](https://datatracker.ietf.org/doc/html/rfc9113) implementation written in Rust with built-in support for [gRPC](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) connections.

Independent benchmarks are available at https://github.com/LesnyRumcajs/grpc_bench/discussions/475.