### PR TITLE
Add protoc-gen-go-mock: ultra lightweight gRPC mock generator for Go

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,6 +205,7 @@
 - [Mortar](https://github.com/go-masonry/mortar) - GO framework for building gRPC (and REST) web services with DI, Telemetry and more
 - [sqlc-grpc](https://github.com/walterwanderley/sqlc-grpc) - Generate gRPC/HTTP server (with metrics, tracing, swagger and grpcui) from SQL
 - [protoc-gen-fieldmask](https://github.com/idodod/protoc-gen-fieldmask) - A protoc plugin that generates fieldmask paths as static type properties of proto messages
+- [protoc-gen-go-mock](https://github.com/kw510/protoc-gen-go-mock) - A protoc plugin for generating minimal gRPC service mocks suitable for use in tests.
 
 
 <a name="lang-nodejs"></a>


### PR DESCRIPTION
This PR adds [protoc-gen-go-mock](https://github.com/kw510/protoc-gen-go-mock) to the Go section. It is a newer, ultra lightweight alternative to existing mock generators like `protoc-gen-mock`, ideal for quick and minimal mock implementations.

Its a tool used for quickly generating mock implementations of gRPC services directly from protobuf definitions.

It is ideal for unit testing and rapid prototyping. Unlike more feature-rich alternatives, it focuses on simplicity and speed, making it a great choice for projects that value ease of use and minimal dependencies