### PR TITLE
Add Protovalidate to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -517,6 +517,7 @@ Tim Burks
 - [GenDocu](https://gendocu.com) - gRPC Documentation and SDK generator as a Service.
 - [protolint](https://github.com/yoheimuta/protolint) - A pluggable linter and fixer to enforce Protocol Buffer style and conventions.
 - [Mouse Melon](https://mousemelon.dev) - A user-friendly Protocol Buffers data editor.
+- [Protovalidate](https://github.com/bufbuild/protovalidate) - Protovalidate provides standard annotations to validate common rules on messages and fields, as well as the ability to use CEL to write custom rules.
 
 ### Similar
 


### PR DESCRIPTION
> Search previous suggestions before making a new one, as yours may be a duplicate

There are no results for "Protovalidate" in open or closed PRs.

> Use gRPC casing

n/a

> If you just created something, wait at least a couple of weeks before submitting

Protovalidate just celebrated the second anniversary of its v0.1.0 release.
 
> You should of course have read or used the thing you're submitting

I use Protovalidate daily.

> Make an individual pull request for each suggestion

This is an individual suggestion and one pull request.

> Use the following format: [name](link) - Description

Done and checked!

> Keep descriptions short and simple, but descriptive

Done.

> Start the description with a capital

Done.

> Check your spelling and grammar

Done.

> Make sure your text editor is set to remove trailing whitespace

Done.

> Link additions should be added to the bottom of the relevant section

Done.

> New categories or improvements to the existing categorization are welcome

No new categories/improvements in this PR.

> Pull requests should have a useful title and include a link to the package and why it should be included

The title for this PR follows the example of the last merged PR. Protovalidate is available at (https://github.com/bufbuild/protovalidate), and should be included as it's the successor to [protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate), another library on this page.