### PR TITLE
Add sugar-proto to C++ section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -332,6 +332,7 @@
 
 - [qtgrpc](https://github.com/qt/qtgrpc) - gRPC and Protobuf generator and bindings for the Qt framework
 - [asio-grpc](https://github.com/Tradias/asio-grpc) - Asynchronous gRPC with [Boost.Asio](https://github.com/boostorg/asio) or [libunifex](https://github.com/facebookexperimental/libunifex)
+- [sugar-proto](https://github.com/illegal-instruction-co/sugar-proto) - A Protobuf wrapper with expressive, minimal, and strongly-typed C++ syntax, close to plain structs.
 
 <a name="lang-ballerina"></a>
 ### Ballerina


### PR DESCRIPTION
This PR adds [sugar-proto](https://github.com/illegal-instruction-co/sugar-proto) to the C++ section.

sugar-proto is a modern C++ wrapper for Protocol Buffers that simplifies message handling and reduces boilerplate.
It provides:
- Expressive, minimal syntax close to plain structs
- Strongly-typed field access
- Ergonomic integration for developers working with gRPC/Protobuf

This makes gRPC development in C++ more productive and approachable, fitting well into the list of language-specific gRPC tools.
